### PR TITLE
Expose North Port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ VOLUME /opt/iotagent-opcua/conf
 
 WORKDIR /opt/iotagent-opcua
 
+# Expose 4041 for NORTH PORT
+EXPOSE ${IOTA_NORTH_PORT:-4041}
+
 COPY docker-entrypoint.sh entrypoint.sh
 
 ENTRYPOINT ./entrypoint.sh


### PR DESCRIPTION
OPC-UA Equivalent of https://github.com/telefonicaid/iotagent-ul/pull/342 (maybe?)

I'm not sure if you need another port exposed by default, or is it all done in the `conf` for now.