### PR TITLE
Update Library version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "opcua-iotagent",
   "license": "AGPL-3.0-only",
   "description": "OPC-UA IoT Agent to interface with NGSI Context Broker",
-  "version": "1.2.0",
+  "version": "1.3.2",
   "homepage": "https://github.com/Engineering-Research-and-Development/iotagent-opcua",
   "keywords": [
     "fiware",
@@ -46,7 +46,7 @@
     "express": "^4.16.3",
     "handlebars": "^4.0.13",
     "http": "0.0.0",
-    "iotagent-node-lib": "2.8.1",
+    "iotagent-node-lib": "2.9.0",
     "jison": "0.4.17",
     "logops": "1.0.0",
     "mongoose": "4.13.17",


### PR DESCRIPTION
Since the **IoT Node Agent** lib has been updated, **OPC-UA** should also create a new release is possible to keep in alignment.


Compare the change with the [Sigfox IoT Agent](https://github.com/telefonicaid/sigfox-iotagent/commit/d9d4b1e7480328cc61c88b03074f91f087f592e5#diff-b9cfc7f2cdf78a7f4b91a753d10865a2)