### PR TITLE
Add double quotation mark replacement

### DIFF
--- a/iot_agent_modules/run/run.js
+++ b/iot_agent_modules/run/run.js
@@ -1238,6 +1238,7 @@ module.exports = {
         function parsePayloadProperties(jsonAttribute) {
             jsonAttribute = jsonAttribute.replace(/:/g, ';');
             jsonAttribute = jsonAttribute.replace(/\*/g, '=');
+            jsonAttribute = jsonAttribute.replace(/&qm/g, '"');
 
             return jsonAttribute;
         }


### PR DESCRIPTION
**&qm** will be replaced with **"** so we can register variables with double quotation mark in its node ID i.e. if we have a variable with the following node ID ```ns=3;s="variable"``` we will specify in the agent payload as ```ns*3:s*&qmvariable&qm```. 