### PR TITLE
Add Mongo-DB User and Password as Docker Secrets

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright 2020 Engineering Ingegneria Informatica S.p.A.
 
-ARG  NODE_VERSION=10.17.0-stretch
+ARG  NODE_VERSION=10.19.0-stretch
 FROM node:${NODE_VERSION}
 
 ARG GITHUB_ACCOUNT=Engineering-Research-and-Development

--- a/docker/README.md
+++ b/docker/README.md
@@ -212,6 +212,9 @@ Currently, this `_FILE` suffix is supported for:
 -   `IOTA_AUTH_PASSWORD`
 -   `IOTA_AUTH_CLIENT_ID`
 -   `IOTA_AUTH_CLIENT_SECRET`
+-   `IOTA_MONGO_USER`
+-   `IOTA_MONGO_PASSWORD`
+
 
 ## Best Practices
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -35,6 +35,8 @@ file_env 'IOTA_AUTH_HOST'
 file_env 'IOTA_AUTH_POST'
 file_env 'IOTA_AUTH_CLIENT_ID'
 file_env 'IOTA_AUTH_CLIENT_SECRET'
+file_env 'IOTA_MONGO_USER'
+file_env 'IOTA_MONGO_PASSWORD'
 
 
 if [[  -z "$IOTA_AUTH_ENABLED" ]]; then


### PR DESCRIPTION
Once Mongo-DB  User and Password are fully supported within the iot-node-lib, they should be made available obfuscated within Docker 

Related: https://github.com/telefonicaid/iotagent-node-lib/pull/852